### PR TITLE
Update trussed-staging and extract manage extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## Unreleased
+
+### Changed
+
+- Use extension crates `trussed-manage` and `trussed-wrap-key-to-file` instead
+  of backend crate `trussed-staging`, see [trussed-staging#19][].
+
+[trussed-staging#19]: https://github.com/trussed-dev/trussed-staging/pull/19
+
 ## [v0.2.0][] (2024-03-04)
 
 [v0.2.0]: https://github.com/Nitrokey/trussed-se050-backend/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 - Use extension crates `trussed-manage` and `trussed-wrap-key-to-file` instead
   of backend crate `trussed-staging`, see [trussed-staging#19][].
+- Move `manage::ManageExtension` into `trussed-se050-manage` crate.
 
 [trussed-staging#19]: https://github.com/trussed-dev/trussed-staging/pull/19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,23 @@
 # Changelog
 
-## Unreleased
+## [Unreleased][]
+
+-
+
+[Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/v0.3.0...HEAD
+
+## [v0.3.0][] (2024-03-15)
+
+[v0.3.0]: https://github.com/Nitrokey/trussed-se050-backend/compare/v0.2.0...v0.3.0
 
 ### Changed
 
 - Use extension crates `trussed-manage` and `trussed-wrap-key-to-file` instead
-  of backend crate `trussed-staging`, see [trussed-staging#19][].
+  of backend crate `trussed-staging` ([#13][])
 - Move `manage::ManageExtension` into `trussed-se050-manage` crate and rename
-  it to `Se050ManageExtension`.
+  it to `Se050ManageExtension` ([#13][])
 
-[trussed-staging#19]: https://github.com/trussed-dev/trussed-staging/pull/19
+[#13]: https://github.com/Nitrokey/trussed-se050-backend/pull/13
 
 ## [v0.2.0][] (2024-03-04)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@
 
 - Use extension crates `trussed-manage` and `trussed-wrap-key-to-file` instead
   of backend crate `trussed-staging`, see [trussed-staging#19][].
-- Move `manage::ManageExtension` into `trussed-se050-manage` crate.
+- Move `manage::ManageExtension` into `trussed-se050-manage` crate and rename
+  it to `Se050ManageExtension`.
 
 [trussed-staging#19]: https://github.com/trussed-dev/trussed-staging/pull/19
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,32 @@
+[workspace]
+members = ["extensions/se050-manage"]
+
+[workspace.package]
+authors = ["Nitrokey GmbH <info@nitrokey.com>"]
+edition = "2021"
+repository = "https://github.com/trussed-dev/trussed-staging"
+license = "Apache-2.0 OR MIT"
+
 [package]
 name = "trussed-se050-backend"
 version = "0.2.0"
-edition = "2021"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[workspace.dependencies]
+serde = { version = "1.0.185", default-features = false, features = ["derive"] }
+trussed = { version = "0.1.0", features = ["serde-extensions"] }
 
 [dependencies]
+serde.workspace = true
+trussed.workspace = true
+
 se05x = { version  = "0.1.1", features = ["serde", "builder"] }
-trussed = { version = "0.1.0", features = ["serde-extensions"] }
 trussed-auth = "0.2.2"
 trussed-manage = "0.1.0"
+trussed-se050-manage = "0.1.0"
 trussed-wrap-key-to-file = "0.1.0"
 delog = "0.1.6"
 embedded-hal = "0.2.7"
@@ -19,7 +36,6 @@ hex-literal = "0.4.1"
 serde-byte-array = "0.1.2"
 iso7816 = "0.1.1"
 hmac = "0.12.1"
-serde = { version = "1.0.185", default-features = false, features = ["derive"] }
 rand = { version = "0.8.5", default-features = false }
 littlefs2 = "0.4.0"
 cbor-smol = "0.4.0"
@@ -38,6 +54,8 @@ trussed-auth = { git = "https://github.com/Nitrokey/trussed-auth", rev = "49c13e
 trussed-manage = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "manage-v0.1.0" }
 trussed-rsa-alloc = { git = "https://github.com/Nitrokey/trussed-rsa-backend.git", rev = "2088e2f8a8d706276c1559717b4c6b6d4f270253" }
 trussed-wrap-key-to-file = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "wrap-key-to-file-v0.1.0" }
+
+trussed-se050-manage = { path = "extensions/se050-manage" }
 
 [features]
 default = ["log-all"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,8 @@ edition = "2021"
 se05x = { version  = "0.1.1", features = ["serde", "builder"] }
 trussed = { version = "0.1.0", features = ["serde-extensions"] }
 trussed-auth = "0.2.2"
-trussed-staging = { version = "0.1.0", features = ["wrap-key-to-file", "manage"] }
+trussed-manage = "0.1.0"
+trussed-wrap-key-to-file = "0.1.0"
 delog = "0.1.6"
 embedded-hal = "0.2.7"
 hkdf = { version = "0.12.3", default-features = false }
@@ -34,8 +35,9 @@ p256-cortex-m4 = { version = "0.1.0-alpha.6", features = ["prehash", "sec1-signa
 littlefs2 = { git = "https://github.com/trussed-dev/littlefs2.git", rev = "ebd27e49ca321089d01d8c9b169c4aeb58ceeeca" }
 trussed = { git = "https://github.com/Nitrokey/trussed.git", tag = "v0.1.0-nitrokey.18" }
 trussed-auth = { git = "https://github.com/Nitrokey/trussed-auth", rev = "49c13eae6d9a225676191d4776d514848e4eab5b" }
+trussed-manage = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "manage-v0.1.0" }
 trussed-rsa-alloc = { git = "https://github.com/Nitrokey/trussed-rsa-backend.git", rev = "2088e2f8a8d706276c1559717b4c6b6d4f270253" }
-trussed-staging = { git = "https://github.com/nitrokey/trussed-staging.git", rev = "59dda984e42fbbbd9b469c773af08b497b913469" }
+trussed-wrap-key-to-file = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "wrap-key-to-file-v0.1.0" }
 
 [features]
 default = ["log-all"]

--- a/extensions/se050-manage/CHANGELOG.md
+++ b/extensions/se050-manage/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Changelog
+
+## [Unreleased][]
+
+-
+
+[Unreleased]: https://github.com/Nitrokey/trussed-se050-backend/compare/se050-manage-v0.1.0...HEAD
+
+## [0.1.0][] - 2024-03-15
+
+- Extract the `ManageExtension` from `trussed-se050-backend` 0.2.0 ([#13][])
+- Rename `ManageExtension` to `Se050ManageExtension` ([#13][])
+
+[#13]: https://github.com/Nitrokey/trussed-se050-backend/pull/13
+
+[0.1.0]: https://github.com/Nitrokey/trussed-se050-backend/releases/tag/se050-manage-v0.1.0

--- a/extensions/se050-manage/Cargo.toml
+++ b/extensions/se050-manage/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "trussed-se050-manage"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+serde.workspace = true
+trussed.workspace = true

--- a/extensions/se050-manage/src/lib.rs
+++ b/extensions/se050-manage/src/lib.rs
@@ -1,3 +1,5 @@
+#![no_std]
+
 use serde::{Deserialize, Serialize};
 use trussed::{
     serde_extensions::{Extension, ExtensionClient, ExtensionResult},
@@ -6,7 +8,7 @@ use trussed::{
 };
 
 #[derive(Debug, Default)]
-pub struct ManageExtension;
+pub struct Se050ManageExtension;
 
 /// Request information regarding the SE050
 #[derive(Debug, Deserialize, Serialize, Copy, Clone)]
@@ -20,38 +22,38 @@ pub struct TestSe050Request;
 
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Deserialize, Serialize)]
-pub enum ManageRequest {
+pub enum Se050ManageRequest {
     Info(InfoRequest),
     TestSe050(TestSe050Request),
 }
 
-impl TryFrom<ManageRequest> for InfoRequest {
+impl TryFrom<Se050ManageRequest> for InfoRequest {
     type Error = Error;
-    fn try_from(request: ManageRequest) -> Result<Self, Self::Error> {
+    fn try_from(request: Se050ManageRequest) -> Result<Self, Self::Error> {
         match request {
-            ManageRequest::Info(request) => Ok(request),
+            Se050ManageRequest::Info(request) => Ok(request),
             _ => Err(Error::InternalError),
         }
     }
 }
 
-impl From<InfoRequest> for ManageRequest {
+impl From<InfoRequest> for Se050ManageRequest {
     fn from(request: InfoRequest) -> Self {
         Self::Info(request)
     }
 }
 
-impl TryFrom<ManageRequest> for TestSe050Request {
+impl TryFrom<Se050ManageRequest> for TestSe050Request {
     type Error = Error;
-    fn try_from(request: ManageRequest) -> Result<Self, Self::Error> {
+    fn try_from(request: Se050ManageRequest) -> Result<Self, Self::Error> {
         match request {
-            ManageRequest::TestSe050(request) => Ok(request),
+            Se050ManageRequest::TestSe050(request) => Ok(request),
             _ => Err(Error::InternalError),
         }
     }
 }
 
-impl From<TestSe050Request> for ManageRequest {
+impl From<TestSe050Request> for Se050ManageRequest {
     fn from(request: TestSe050Request) -> Self {
         Self::TestSe050(request)
     }
@@ -70,22 +72,22 @@ pub struct InfoReply {
 }
 
 #[derive(Debug, Deserialize, Serialize)]
-pub enum ManageReply {
+pub enum Se050ManageReply {
     Info(InfoReply),
     TestSe050(TestSe050Reply),
 }
 
-impl TryFrom<ManageReply> for InfoReply {
+impl TryFrom<Se050ManageReply> for InfoReply {
     type Error = Error;
-    fn try_from(request: ManageReply) -> Result<Self, Self::Error> {
+    fn try_from(request: Se050ManageReply) -> Result<Self, Self::Error> {
         match request {
-            ManageReply::Info(request) => Ok(request),
+            Se050ManageReply::Info(request) => Ok(request),
             _ => Err(Error::InternalError),
         }
     }
 }
 
-impl From<InfoReply> for ManageReply {
+impl From<InfoReply> for Se050ManageReply {
     fn from(request: InfoReply) -> Self {
         Self::Info(request)
     }
@@ -96,32 +98,32 @@ pub struct TestSe050Reply {
     pub reply: Bytes<1024>,
 }
 
-impl TryFrom<ManageReply> for TestSe050Reply {
+impl TryFrom<Se050ManageReply> for TestSe050Reply {
     type Error = Error;
-    fn try_from(request: ManageReply) -> Result<Self, Self::Error> {
+    fn try_from(request: Se050ManageReply) -> Result<Self, Self::Error> {
         match request {
-            ManageReply::TestSe050(request) => Ok(request),
+            Se050ManageReply::TestSe050(request) => Ok(request),
             _ => Err(Error::InternalError),
         }
     }
 }
 
-impl From<TestSe050Reply> for ManageReply {
+impl From<TestSe050Reply> for Se050ManageReply {
     fn from(request: TestSe050Reply) -> Self {
         Self::TestSe050(request)
     }
 }
 
-impl Extension for ManageExtension {
-    type Request = ManageRequest;
-    type Reply = ManageReply;
+impl Extension for Se050ManageExtension {
+    type Request = Se050ManageRequest;
+    type Reply = Se050ManageReply;
 }
 
-pub type ManageResult<'a, R, C> = ExtensionResult<'a, ManageExtension, R, C>;
+pub type Se050ManageResult<'a, R, C> = ExtensionResult<'a, Se050ManageExtension, R, C>;
 
-pub trait ManageClient: ExtensionClient<ManageExtension> {
+pub trait Se050ManageClient: ExtensionClient<Se050ManageExtension> {
     /// Get info on the SE050
-    fn get_info(&mut self) -> ManageResult<'_, InfoReply, Self> {
+    fn get_info(&mut self) -> Se050ManageResult<'_, InfoReply, Self> {
         self.extension(InfoRequest)
     }
 
@@ -129,9 +131,9 @@ pub trait ManageClient: ExtensionClient<ManageExtension> {
     ///
     /// This will fake the results of the tests from v0.1.0-test-driver for compatibility but
     /// return correct metadata header to be shown in the test result
-    fn test_se050(&mut self) -> ManageResult<'_, TestSe050Reply, Self> {
+    fn test_se050(&mut self) -> Se050ManageResult<'_, TestSe050Reply, Self> {
         self.extension(TestSe050Request)
     }
 }
 
-impl<C: ExtensionClient<ManageExtension>> ManageClient for C {}
+impl<C: ExtensionClient<Se050ManageExtension>> Se050ManageClient for C {}

--- a/extensions/se050-manage/src/lib.rs
+++ b/extensions/se050-manage/src/lib.rs
@@ -1,0 +1,137 @@
+use serde::{Deserialize, Serialize};
+use trussed::{
+    serde_extensions::{Extension, ExtensionClient, ExtensionResult},
+    types::Bytes,
+    Error,
+};
+
+#[derive(Debug, Default)]
+pub struct ManageExtension;
+
+/// Request information regarding the SE050
+#[derive(Debug, Deserialize, Serialize, Copy, Clone)]
+pub struct InfoRequest;
+
+/// Test SE050 functionality
+///
+/// This is now a placeholder for the previous test. It is kept to return available space on the SE050
+#[derive(Debug, Deserialize, Serialize, Copy, Clone)]
+pub struct TestSe050Request;
+
+#[allow(clippy::large_enum_variant)]
+#[derive(Debug, Deserialize, Serialize)]
+pub enum ManageRequest {
+    Info(InfoRequest),
+    TestSe050(TestSe050Request),
+}
+
+impl TryFrom<ManageRequest> for InfoRequest {
+    type Error = Error;
+    fn try_from(request: ManageRequest) -> Result<Self, Self::Error> {
+        match request {
+            ManageRequest::Info(request) => Ok(request),
+            _ => Err(Error::InternalError),
+        }
+    }
+}
+
+impl From<InfoRequest> for ManageRequest {
+    fn from(request: InfoRequest) -> Self {
+        Self::Info(request)
+    }
+}
+
+impl TryFrom<ManageRequest> for TestSe050Request {
+    type Error = Error;
+    fn try_from(request: ManageRequest) -> Result<Self, Self::Error> {
+        match request {
+            ManageRequest::TestSe050(request) => Ok(request),
+            _ => Err(Error::InternalError),
+        }
+    }
+}
+
+impl From<TestSe050Request> for ManageRequest {
+    fn from(request: TestSe050Request) -> Self {
+        Self::TestSe050(request)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Copy, Clone)]
+pub struct InfoReply {
+    pub major: u8,
+    pub minor: u8,
+    pub patch: u8,
+    pub sb_major: u8,
+    pub sb_minor: u8,
+    pub persistent: u16,
+    pub transient_deselect: u16,
+    pub transient_reset: u16,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub enum ManageReply {
+    Info(InfoReply),
+    TestSe050(TestSe050Reply),
+}
+
+impl TryFrom<ManageReply> for InfoReply {
+    type Error = Error;
+    fn try_from(request: ManageReply) -> Result<Self, Self::Error> {
+        match request {
+            ManageReply::Info(request) => Ok(request),
+            _ => Err(Error::InternalError),
+        }
+    }
+}
+
+impl From<InfoReply> for ManageReply {
+    fn from(request: InfoReply) -> Self {
+        Self::Info(request)
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct TestSe050Reply {
+    pub reply: Bytes<1024>,
+}
+
+impl TryFrom<ManageReply> for TestSe050Reply {
+    type Error = Error;
+    fn try_from(request: ManageReply) -> Result<Self, Self::Error> {
+        match request {
+            ManageReply::TestSe050(request) => Ok(request),
+            _ => Err(Error::InternalError),
+        }
+    }
+}
+
+impl From<TestSe050Reply> for ManageReply {
+    fn from(request: TestSe050Reply) -> Self {
+        Self::TestSe050(request)
+    }
+}
+
+impl Extension for ManageExtension {
+    type Request = ManageRequest;
+    type Reply = ManageReply;
+}
+
+pub type ManageResult<'a, R, C> = ExtensionResult<'a, ManageExtension, R, C>;
+
+pub trait ManageClient: ExtensionClient<ManageExtension> {
+    /// Get info on the SE050
+    fn get_info(&mut self) -> ManageResult<'_, InfoReply, Self> {
+        self.extension(InfoRequest)
+    }
+
+    /// Test the se050 device and driver
+    ///
+    /// This will fake the results of the tests from v0.1.0-test-driver for compatibility but
+    /// return correct metadata header to be shown in the test result
+    fn test_se050(&mut self) -> ManageResult<'_, TestSe050Reply, Self> {
+        self.extension(TestSe050Request)
+    }
+}
+
+impl<C: ExtensionClient<ManageExtension>> ManageClient for C {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ use trussed_auth_impl::{AuthContext, HardwareKey};
 mod staging;
 
 mod core_api;
-pub mod manage;
+mod manage;
 pub mod namespacing;
 
 /// Need overhead for TLV + SW bytes

--- a/src/manage.rs
+++ b/src/manage.rs
@@ -7,128 +7,18 @@ use se05x::{
     },
     t1::I2CForT1,
 };
-use serde::{Deserialize, Serialize};
 use trussed::{
-    serde_extensions::{Extension, ExtensionClient, ExtensionImpl, ExtensionResult},
+    serde_extensions::{Extension, ExtensionImpl},
     service::ServiceResources,
     types::Bytes,
     types::CoreContext,
     Error,
 };
+use trussed_se050_manage::{
+    InfoReply, InfoRequest, ManageExtension, ManageRequest, TestSe050Reply,
+};
 
 use crate::Se050Backend;
-
-#[derive(Debug, Default)]
-pub struct ManageExtension;
-
-/// Request information regarding the SE050
-#[derive(Debug, Deserialize, Serialize, Copy, Clone)]
-pub struct InfoRequest;
-
-/// Test SE050 functionality
-///
-/// This is now a placeholder for the previous test. It is kept to return available space on the SE050
-#[derive(Debug, Deserialize, Serialize, Copy, Clone)]
-pub struct TestSe050Request;
-
-#[allow(clippy::large_enum_variant)]
-#[derive(Debug, Deserialize, Serialize)]
-pub enum ManageRequest {
-    Info(InfoRequest),
-    TestSe050(TestSe050Request),
-}
-
-impl TryFrom<ManageRequest> for InfoRequest {
-    type Error = Error;
-    fn try_from(request: ManageRequest) -> Result<Self, Self::Error> {
-        match request {
-            ManageRequest::Info(request) => Ok(request),
-            _ => Err(Error::InternalError),
-        }
-    }
-}
-
-impl From<InfoRequest> for ManageRequest {
-    fn from(request: InfoRequest) -> Self {
-        Self::Info(request)
-    }
-}
-
-impl TryFrom<ManageRequest> for TestSe050Request {
-    type Error = Error;
-    fn try_from(request: ManageRequest) -> Result<Self, Self::Error> {
-        match request {
-            ManageRequest::TestSe050(request) => Ok(request),
-            _ => Err(Error::InternalError),
-        }
-    }
-}
-
-impl From<TestSe050Request> for ManageRequest {
-    fn from(request: TestSe050Request) -> Self {
-        Self::TestSe050(request)
-    }
-}
-
-#[derive(Debug, Deserialize, Serialize, Copy, Clone)]
-pub struct InfoReply {
-    pub major: u8,
-    pub minor: u8,
-    pub patch: u8,
-    pub sb_major: u8,
-    pub sb_minor: u8,
-    pub persistent: u16,
-    pub transient_deselect: u16,
-    pub transient_reset: u16,
-}
-
-#[derive(Debug, Deserialize, Serialize)]
-pub enum ManageReply {
-    Info(InfoReply),
-    TestSe050(TestSe050Reply),
-}
-
-impl TryFrom<ManageReply> for InfoReply {
-    type Error = Error;
-    fn try_from(request: ManageReply) -> Result<Self, Self::Error> {
-        match request {
-            ManageReply::Info(request) => Ok(request),
-            _ => Err(Error::InternalError),
-        }
-    }
-}
-
-impl From<InfoReply> for ManageReply {
-    fn from(request: InfoReply) -> Self {
-        Self::Info(request)
-    }
-}
-
-#[derive(Debug, Deserialize, Serialize, Clone)]
-pub struct TestSe050Reply {
-    pub reply: Bytes<1024>,
-}
-
-impl TryFrom<ManageReply> for TestSe050Reply {
-    type Error = Error;
-    fn try_from(request: ManageReply) -> Result<Self, Self::Error> {
-        match request {
-            ManageReply::TestSe050(request) => Ok(request),
-            _ => Err(Error::InternalError),
-        }
-    }
-}
-
-impl From<TestSe050Reply> for ManageReply {
-    fn from(request: TestSe050Reply) -> Self {
-        Self::TestSe050(request)
-    }
-}
-
-impl Extension for ManageExtension {
-    type Request = ManageRequest;
-    type Reply = ManageReply;
-}
 
 impl<Twi: I2CForT1, D: DelayUs<u32>> ExtensionImpl<ManageExtension> for Se050Backend<Twi, D> {
     fn extension_request<P: trussed::Platform>(
@@ -264,22 +154,3 @@ impl<Twi: I2CForT1, D: DelayUs<u32>> ExtensionImpl<ManageExtension> for Se050Bac
         }
     }
 }
-
-type ManageResult<'a, R, C> = ExtensionResult<'a, ManageExtension, R, C>;
-
-pub trait ManageClient: ExtensionClient<ManageExtension> {
-    /// Get info on the SE050
-    fn get_info(&mut self) -> ManageResult<'_, InfoReply, Self> {
-        self.extension(InfoRequest)
-    }
-
-    /// Test the se050 device and driver
-    ///
-    /// This will fake the results of the tests from v0.1.0-test-driver for compatibility but
-    /// return correct metadata header to be shown in the test result
-    fn test_se050(&mut self) -> ManageResult<'_, TestSe050Reply, Self> {
-        self.extension(TestSe050Request)
-    }
-}
-
-impl<C: ExtensionClient<ManageExtension>> ManageClient for C {}

--- a/src/manage.rs
+++ b/src/manage.rs
@@ -15,19 +15,19 @@ use trussed::{
     Error,
 };
 use trussed_se050_manage::{
-    InfoReply, InfoRequest, ManageExtension, ManageRequest, TestSe050Reply,
+    InfoReply, InfoRequest, Se050ManageExtension, Se050ManageRequest, TestSe050Reply,
 };
 
 use crate::Se050Backend;
 
-impl<Twi: I2CForT1, D: DelayUs<u32>> ExtensionImpl<ManageExtension> for Se050Backend<Twi, D> {
+impl<Twi: I2CForT1, D: DelayUs<u32>> ExtensionImpl<Se050ManageExtension> for Se050Backend<Twi, D> {
     fn extension_request<P: trussed::Platform>(
         &mut self,
         _core_ctx: &mut CoreContext,
         _backend_ctx: &mut Self::Context,
-        request: &<ManageExtension as Extension>::Request,
+        request: &<Se050ManageExtension as Extension>::Request,
         _resources: &mut ServiceResources<P>,
-    ) -> Result<<ManageExtension as Extension>::Reply, Error> {
+    ) -> Result<<Se050ManageExtension as Extension>::Reply, Error> {
         self.configure().map_err(|err| {
             debug!("Failed to enable for management: {err:?}");
             err
@@ -35,7 +35,7 @@ impl<Twi: I2CForT1, D: DelayUs<u32>> ExtensionImpl<ManageExtension> for Se050Bac
 
         debug!("Runnig manage request: {request:?}");
         match request {
-            ManageRequest::Info(InfoRequest) => {
+            Se050ManageRequest::Info(InfoRequest) => {
                 let buf = &mut [0; 128];
                 let atr = self
                     .se
@@ -97,7 +97,7 @@ impl<Twi: I2CForT1, D: DelayUs<u32>> ExtensionImpl<ManageExtension> for Se050Bac
                 }
                 .into())
             }
-            ManageRequest::TestSe050(_) => {
+            Se050ManageRequest::TestSe050(_) => {
                 let mut buf = [b'a'; 128];
                 let mut reply = Bytes::new();
                 let atr = self.enable()?;

--- a/src/staging.rs
+++ b/src/staging.rs
@@ -14,8 +14,8 @@ use trussed::{
     types::{CoreContext, StorageAttributes},
     Error,
 };
-use trussed_staging::manage::{self, ManageExtension, ManageRequest};
-use trussed_staging::wrap_key_to_file::{
+use trussed_manage::{ManageExtension, ManageRequest};
+use trussed_wrap_key_to_file::{
     reply as ext_reply, WrapKeyToFileExtension, WrapKeyToFileReply, WrapKeyToFileRequest,
 };
 
@@ -93,7 +93,7 @@ impl<Twi: I2CForT1, D: DelayUs<u32>> ExtensionImpl<ManageExtension> for Se050Bac
         _resources: &mut ServiceResources<P>,
     ) -> Result<<ManageExtension as trussed::serde_extensions::Extension>::Reply, Error> {
         match request {
-            ManageRequest::FactoryResetDevice(manage::FactoryResetDeviceRequest) => {
+            ManageRequest::FactoryResetDevice(trussed_manage::FactoryResetDeviceRequest) => {
                 let mut buf = [b'a'; 128];
                 let data = &hex!("31323334");
 
@@ -146,7 +146,9 @@ impl<Twi: I2CForT1, D: DelayUs<u32>> ExtensionImpl<ManageExtension> for Se050Bac
                 // Let the staging backend delete the rest of the data
                 Err(Error::RequestNotAvailable)
             }
-            ManageRequest::FactoryResetClient(manage::FactoryResetClientRequest { client }) => {
+            ManageRequest::FactoryResetClient(trussed_manage::FactoryResetClientRequest {
+                client,
+            }) => {
                 let ns = self.ns.for_client(client).ok_or_else(|| {
                     debug_now!("Attempt to factory reset client not handled by the SE050 backend");
                     Error::RequestNotAvailable


### PR DESCRIPTION
This PR adapts to the extensions being extracted from `trussed-staging` in https://github.com/trussed-dev/trussed-staging/pull/19 and also extracts `trussed_se050_backend::manage::ManageExtension` into a separate crate, `trussed-se050-manage`.  To avoid confusion with the `trussed_manage::ManageExtension`, it is also renamed to `Se050ManageExtension`.