### PR TITLE
Core api: make the configuration of the SE050 lazy.

### DIFF
--- a/src/manage.rs
+++ b/src/manage.rs
@@ -28,11 +28,6 @@ impl<Twi: I2CForT1, D: DelayUs<u32>> ExtensionImpl<Se050ManageExtension> for Se0
         request: &<Se050ManageExtension as Extension>::Request,
         _resources: &mut ServiceResources<P>,
     ) -> Result<<Se050ManageExtension as Extension>::Reply, Error> {
-        self.configure().map_err(|err| {
-            debug!("Failed to enable for management: {err:?}");
-            err
-        })?;
-
         debug!("Runnig manage request: {request:?}");
         match request {
             Se050ManageRequest::Info(InfoRequest) => {
@@ -98,6 +93,11 @@ impl<Twi: I2CForT1, D: DelayUs<u32>> ExtensionImpl<Se050ManageExtension> for Se0
                 .into())
             }
             Se050ManageRequest::TestSe050(_) => {
+                self.configure().map_err(|err| {
+                    debug!("Failed to enable for test: {err:?}");
+                    err
+                })?;
+
                 let mut buf = [b'a'; 128];
                 let mut reply = Bytes::new();
                 let atr = self.enable()?;

--- a/src/staging.rs
+++ b/src/staging.rs
@@ -31,6 +31,11 @@ impl<Twi: I2CForT1, D: DelayUs<u32>> ExtensionImpl<WrapKeyToFileExtension>
         request: &WrapKeyToFileRequest,
         resources: &mut ServiceResources<P>,
     ) -> Result<WrapKeyToFileReply, Error> {
+        self.configure().map_err(|err| {
+            debug!("Failed to enable for wrapkey: {err:?}");
+            err
+        })?;
+
         // FIXME: Have a real implementation from trussed
         let mut backend_path = core_ctx.path.clone();
         backend_path.push(&PathBuf::from(BACKEND_DIR));


### PR DESCRIPTION
This is a performance improvement for commands that should not touch the se050

Fix #27 