### PR TITLE
EcDSA signatures: follow requested serialization format

### DIFF
--- a/src/core_api.rs
+++ b/src/core_api.rs
@@ -1782,9 +1782,18 @@ impl<Twi: I2CForT1, D: DelayUs<u32>> Se050Backend<Twi, D> {
             error!("Failed to parse DER signature: {_err:?}");
             Error::FunctionFailed
         })?;
-        let mut signature = Bytes::new();
-        assert!(signature.capacity() > 2 * field_byte_size);
-        signature.extend(signature_der.to_bytes(field_byte_size));
+
+        let signature = match req.format {
+            trussed::types::SignatureSerialization::Asn1Der => {
+                Bytes::from_slice(res.signature).expect("~Signature should fit")
+            }
+            trussed::types::SignatureSerialization::Raw => {
+                let mut signature = Bytes::new();
+                assert!(signature.capacity() > 2 * field_byte_size);
+                signature.extend(signature_der.to_bytes(field_byte_size));
+                signature
+            }
+        };
 
         if let Some(key_id) = volatile_key_id {
             self.clear_volatile_key(key_id)?;

--- a/src/core_api.rs
+++ b/src/core_api.rs
@@ -1784,9 +1784,11 @@ impl<Twi: I2CForT1, D: DelayUs<u32>> Se050Backend<Twi, D> {
         })?;
 
         let signature = match req.format {
-            trussed::types::SignatureSerialization::Asn1Der => {
-                Bytes::from_slice(res.signature).expect("~Signature should fit")
-            }
+            trussed::types::SignatureSerialization::Asn1Der => Bytes::from_slice(res.signature)
+                .map_err(|_err| {
+                    error_now!("Failed to write signature to response: {_err:?}");
+                })
+                .unwrap(),
             trussed::types::SignatureSerialization::Raw => {
                 let mut signature = Bytes::new();
                 assert!(signature.capacity() > 2 * field_byte_size);

--- a/src/trussed_auth_impl.rs
+++ b/src/trussed_auth_impl.rs
@@ -210,7 +210,10 @@ impl<Twi: I2CForT1, D: DelayUs<u32>> Se050Backend<Twi, D> {
         let mut out = Key::default();
         #[allow(clippy::expect_used)]
         kdf.expand(client_id.as_ref().as_bytes(), &mut *out)
-            .expect("Out data is always valid");
+            .map_err(|_err| {
+                error_now!("Out data is always valid: {_err:?}");
+            })
+            .unwrap();
         out
     }
 

--- a/src/trussed_auth_impl/data.rs
+++ b/src/trussed_auth_impl/data.rs
@@ -99,7 +99,10 @@ fn load_app_salt<S: Filestore>(fs: &mut S, location: Location) -> Result<Salt, E
 pub fn expand_app_key(salt: &Salt, application_key: &Key, info: &[u8]) -> Key {
     #[allow(clippy::expect_used)]
     let mut hmac = Hmac::<Sha256>::new_from_slice(&**application_key)
-        .expect("Slice will always be of acceptable size");
+        .map_err(|_err| {
+            error_now!("Slice will always be of acceptable size: {_err:?}");
+        })
+        .unwrap();
     hmac.update(&**salt);
     hmac.update(&(info.len() as u64).to_be_bytes());
     hmac.update(info);
@@ -118,7 +121,10 @@ fn pin_len(pin: &[u8]) -> u8 {
 pub fn expand_pin_key(salt: &Salt, application_key: &Key, id: PinId, pin: &[u8]) -> PinKey {
     #[allow(clippy::expect_used)]
     let mut hmac = Hmac::<Sha256>::new_from_slice(&**application_key)
-        .expect("Slice will always be of acceptable size");
+        .map_err(|_err| {
+            error_now!("Slice will always be of acceptable size: {_err:?}");
+        })
+        .unwrap();
     hmac.update(&[u8::from(id)]);
     hmac.update(&[pin_len(pin)]);
     hmac.update(pin);


### PR DESCRIPTION
Opcard only ever needed `raw`, but PIV needs the ASN.1 format