### PR TITLE
 Use trussed_core::types::EncryptedData 

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ trussed.workspace = true
 
 se05x = { version  = "0.1.5", features = ["serde", "builder"] }
 trussed-auth = "0.3.0"
+trussed-core = "0.1"
 trussed-manage = "0.1.0"
 trussed-se050-manage = "0.1.0"
 trussed-wrap-key-to-file = "0.1.0"
@@ -58,7 +59,8 @@ serde_test = "1.0.176"
 
 [patch.crates-io]
 ctaphid-dispatch = { git = "https://github.com/trussed-dev/ctaphid-dispatch.git", rev = "57cb3317878a8593847595319aa03ef17c29ec5b" }
-trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "046478b7a4f6e2315acf9112d98308379c2e3eee" }
+trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "eadd27cda0f457caae609e7fa972277e46695bd3" }
+trussed-core = { git = "https://github.com/trussed-dev/trussed.git", rev = "eadd27cda0f457caae609e7fa972277e46695bd3" }
 trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth.git", rev = "c030b82ad3441f337af09afe3a69e8a6da5785ea" }
 trussed-manage = { git = "https://github.com/trussed-dev/trussed-staging.git", tag = "manage-v0.1.0" }
 trussed-rsa-alloc = { git = "https://github.com/trussed-dev/trussed-rsa-backend.git", tag = "v0.2.1" }


### PR DESCRIPTION
Previously, we serialized trussed::api::reply::Encrypt directly.  We have removed the serde trait implementations for the Trussed request and reply structs so this patch updates WrappedKeyData to use the EncryptedData struct instead.

See also: https://github.com/trussed-dev/trussed/issues/183