### PR TITLE
Update trussed-auth

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,8 @@ trussed-core = { workspace = true, features = ["brainpoolp256r1", "brainpoolp384
 
 se05x = { version  = "0.1.5", features = ["serde", "builder"] }
 trussed = { version = "0.1.0", default-features = false, features = ["chacha8-poly1305", "crypto-client", "serde-extensions"] }
-trussed-auth = "0.3.0"
+trussed-auth = "0.4"
+trussed-auth-backend = "0.1"
 trussed-manage = "0.2.0"
 trussed-se050-manage = "0.2.0"
 trussed-wrap-key-to-file = "0.2.0"
@@ -58,7 +59,7 @@ serde_test = "1.0.176"
 
 [patch.crates-io]
 trussed = { git = "https://github.com/trussed-dev/trussed.git", rev = "6bba8fde36d05c0227769eb63345744e87d84b2b" }
-trussed-auth = { git = "https://github.com/trussed-dev/trussed-auth", rev = "fc53539536d7658c45a492585041742d8cdc45d0" }
+trussed-auth-backend = { git = "https://github.com/trussed-dev/trussed-auth", tag = "v0.4.0" }
 trussed-rsa-alloc = { git = "https://github.com/trussed-dev/trussed-rsa-backend.git", rev = "743d9aaa3d8a17d7dbf492bd54dc18ab8fca3dc0" }
 admin-app = { git = "https://github.com/Nitrokey/admin-app.git", rev = "d5f1c6df405e4edeb6524f908c1c713139173e81" }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,7 @@ extern crate delog;
 generate_macros!();
 
 mod trussed_auth_impl;
-use trussed_auth::MAX_HW_KEY_LEN;
+use trussed_auth_backend::MAX_HW_KEY_LEN;
 use trussed_auth_impl::{AuthContext, HardwareKey};
 
 mod staging;

--- a/src/trussed_auth_impl.rs
+++ b/src/trussed_auth_impl.rs
@@ -19,7 +19,7 @@ use trussed::{
     types::{Location, PathBuf},
     Bytes,
 };
-use trussed_auth::MAX_HW_KEY_LEN;
+use trussed_auth_backend::MAX_HW_KEY_LEN;
 
 pub(crate) mod data;
 


### PR DESCRIPTION
This crate also depends on `trussed-auth-backend` because of the `MAX_HW_KEY_LEN` constant.  Would it make sense to move it into `trussed-auth` too?