### PR TITLE
Parenthesize shift expression

### DIFF
--- a/src/namespacing.rs
+++ b/src/namespacing.rs
@@ -393,7 +393,7 @@ pub(crate) fn parse_key_id(id: KeyId, ns: NamespaceValue) -> Option<(ParsedObjec
         return None;
     }
 
-    let ty = (((val & 0xFFFF << TY_OFFSET) >> TY_OFFSET) as u16)
+    let ty = (((val & (0xFFFF << TY_OFFSET)) >> TY_OFFSET) as u16)
         .try_into()
         .ok()?;
 


### PR DESCRIPTION
This fixes a new clippy lint ([clippy::precedence](https://rust-lang.github.io/rust-clippy/stable/index.html#precedence)).