### PR TITLE
Fix sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,12 @@
 
 ### Changed
 
+- Do not close sessions when authentication fails ([#54][])
 - Update `cbor-smol` dependency to v0.5.0
 - Update `trussed-se050-manage` dependency to v0.2.0
 
 [Unreleased]: https://github.com/trussed-dev/trussed-staging/compare/v0.3.0...HEAD
+[#54]: https://github.com/Nitrokey/trussed-se050-backend/pull/54#pullrequestreview-2873970779
 
 ## [v0.3.6][] (2024-10-17)
 

--- a/src/core_api/ecdsa_der.rs
+++ b/src/core_api/ecdsa_der.rs
@@ -30,10 +30,9 @@ impl<'a> DerSignature<'a> {
         let r_begin = field_bytes_size.saturating_sub(self.r.as_bytes().len());
         let s_begin = field_bytes_size.saturating_sub(self.s.as_bytes().len());
 
-        iter::repeat(0)
-            .take(r_begin)
+        iter::repeat_n(0, r_begin)
             .chain(self.r.as_bytes().iter().cloned())
-            .chain(iter::repeat(0).take(s_begin))
+            .chain(iter::repeat_n(0, s_begin))
             .chain(self.s.as_bytes().iter().cloned())
     }
 }

--- a/src/trussed_auth_impl.rs
+++ b/src/trussed_auth_impl.rs
@@ -264,6 +264,7 @@ impl<Twi: I2CForT1, D: Delay> ExtensionImpl<trussed_auth::AuthExtension> for Se0
         <trussed_auth::AuthExtension as trussed::serde_extensions::Extension>::Reply,
         trussed::Error,
     > {
+        self.configure()?;
         let backend_ctx = backend_ctx.with_namespace(&self.ns, &core_ctx.path);
         let auth_ctx = backend_ctx.auth;
         let ns = backend_ctx.ns;

--- a/src/trussed_auth_impl/data.rs
+++ b/src/trussed_auth_impl/data.rs
@@ -386,7 +386,10 @@ impl PinData {
             }
             // Failed session do not need to be closed
             Ok(false) => return Ok(None),
-            Err(err) => Err(err.into()),
+            Err(err) => {
+                error!("Failed to authenticate: {err:?}");
+                return Err(err.into());
+            }
         };
         se050.run_session_command(session_id, &CloseSession {}, buf)?;
         res

--- a/src/trussed_auth_impl/data.rs
+++ b/src/trussed_auth_impl/data.rs
@@ -337,11 +337,13 @@ impl PinData {
             .inspect_err(|_err| {
                 error!("Failed to authenticate pin: {_err:?}");
             })?;
-        se050
-            .run_session_command(session_id, &CloseSession {}, buf)
-            .inspect_err(|_err| {
-                error!("Failed to close session: {_err:?}");
-            })?;
+        if res {
+            se050
+                .run_session_command(session_id, &CloseSession {}, buf)
+                .inspect_err(|_err| {
+                    error!("Failed to close session: {_err:?}");
+                })?;
+        }
         debug!("Check succeeded with {res:?}");
         Ok(res)
     }
@@ -382,7 +384,8 @@ impl PinData {
                         .map_err(|_| Error::DeserializationFailed)?,
                 ))
             }
-            Ok(false) => Ok(None),
+            // Failed session do not need to be closed
+            Ok(false) => return Ok(None),
             Err(err) => Err(err.into()),
         };
         se050.run_session_command(session_id, &CloseSession {}, buf)?;


### PR DESCRIPTION
Do not attempt to close failed open sessions.

Form the documentation:

> ### 3.6.5 Session closure
> Note that sessions can only be closed if the session is fully set up; i.e., authentication must be finished successfully.