### PR TITLE
Remove duplicate configure

### DIFF
--- a/src/staging.rs
+++ b/src/staging.rs
@@ -50,8 +50,6 @@ impl<Twi: I2CForT1, D: Delay> ExtensionImpl<WrapKeyToFileExtension> for Se050Bac
         request: &WrapKeyToFileRequest,
         resources: &mut ServiceResources<P>,
     ) -> Result<WrapKeyToFileReply, Error> {
-        self.configure()?;
-
         // FIXME: Have a real implementation from trussed
         let mut backend_path = core_ctx.path.clone();
         backend_path.push(BACKEND_DIR);
@@ -504,8 +502,6 @@ impl<Twi: I2CForT1, D: Delay> ExtensionImpl<HpkeExtension> for Se050Backend<Twi,
         request: &<HpkeExtension as trussed::serde_extensions::Extension>::Request,
         resources: &mut ServiceResources<P>,
     ) -> Result<<HpkeExtension as trussed::serde_extensions::Extension>::Reply, Error> {
-        self.configure()?;
-
         // FIXME: Have a real implementation from trussed
         let mut backend_path = core_ctx.path.clone();
         backend_path.push(BACKEND_DIR);

--- a/src/trussed_auth_impl.rs
+++ b/src/trussed_auth_impl.rs
@@ -264,7 +264,6 @@ impl<Twi: I2CForT1, D: Delay> ExtensionImpl<trussed_auth::AuthExtension> for Se0
         <trussed_auth::AuthExtension as trussed::serde_extensions::Extension>::Reply,
         trussed::Error,
     > {
-        self.configure()?;
         let backend_ctx = backend_ctx.with_namespace(&self.ns, &core_ctx.path);
         let auth_ctx = backend_ctx.auth;
         let ns = backend_ctx.ns;


### PR DESCRIPTION
Configure is now called on boot: https://github.com/Nitrokey/nitrokey-3-firmware/blob/86169ac7358b3ab4119b3a407f7d2f5fb6545eca/components/apps/src/lib.rs#L663

This slowed down every call that went through the SE050 backend.